### PR TITLE
Adds spotify playlist/album support and `/stop` and `/skip` commands

### DIFF
--- a/djyosof/cogs/audio_player.py
+++ b/djyosof/cogs/audio_player.py
@@ -4,6 +4,8 @@ from discord.ext import commands
 from discord.commands import slash_command
 from settings import CONFIG
 
+from djyosof.cogs import utilities
+
 
 class AudioPlayerCog(commands.Cog):
     def __init__(self, bot) -> None:
@@ -23,12 +25,36 @@ class AudioPlayerCog(commands.Cog):
 
         queue_markdown = ""
         for idx, track in enumerate(
-            list(self.bot.audio_players[interaction.guild_id].queue._queue)
+            list(self.bot.audio_players[interaction.guild_id].queue._queue)[:10]
         ):
-            queue_markdown += f"**{idx+1}**. {track.name} - {track.artist}\n"
+            queue_markdown += f"  **{idx+1}**. {track.name} - {track.artist}\n"
 
         if queue_markdown == "":
             queue_markdown = "Queue is empty!"
+        else:
+            queue_markdown += f"\nShowing 10 out of {len(list(self.bot.audio_players[interaction.guild_id].queue._queue))} tracks in the queue."
 
         embed.add_field(name="Queue", value=queue_markdown)
         await interaction.response.send_message("Current Queue", embed=embed)
+
+    @slash_command(guild_ids=CONFIG.get("guild_ids"))
+    async def skip(self, interaction: Interaction):
+        audio_player = self.bot.audio_players[interaction.guild_id]
+        voice = await utilities.connect_or_move(interaction)
+        if not voice:
+            await interaction.response.send_message(
+                "Unable to connect to a voice channel :("
+            )
+        audio_player.skip(voice)
+        await interaction.response.send_message("Song skipped!")
+
+    @slash_command(guild_ids=CONFIG.get("guild_ids"))
+    async def stop(self, interaction: Interaction):
+        audio_player = self.bot.audio_players[interaction.guild_id]
+        voice = await utilities.connect_or_move(interaction)
+        if not voice:
+            await interaction.response.send_message(
+                "Unable to connect to a voice channel :("
+            )
+        audio_player.stop(voice)
+        await interaction.response.send_message("Queue cleared and player stopped.")

--- a/djyosof/cogs/spotify.py
+++ b/djyosof/cogs/spotify.py
@@ -18,20 +18,36 @@ class SpotifyCog(commands.Cog):
     async def spotify(
         self,
         interaction: Interaction,
-        query: Option(str, "Query to search for", required=True),
+        query: Option(str, "Query to search for", required=False),
+        link: Option(str, "Link to Spotify media", required=False),
     ):
-        tracks = self.bot.players[AudioType.SPOTIFY].search(query)
+        if not query and not link:
+            return
 
-        embed = discord.Embed(
-            title="",
-            color=discord.Colour.blurple(),
-        )
+        if link:
+            tracks = self.bot.players[AudioType.SPOTIFY].open_link(link)
+            await self.bot.audio_players[interaction.guild_id].enqueue_and_play(
+                track[:1], voice, interaction
+            )
+            for track in tracks[1:]:
+                await self.bot.audio_players[interaction.guild_id].enqueue(
+                    track, voice, interaction
+                )
 
-        tracklist_markdown = ""
-        for idx, track in enumerate(tracks):
-            tracklist_markdown += f"**{idx+1}**. {track.name} - {track.artist}\n"
 
-        embed.add_field(name="Search Results", value=tracklist_markdown)
+        if query
+            tracks = self.bot.players[AudioType.SPOTIFY].search(query)
 
-        view = SearchView(tracks, self.bot)
-        await interaction.response.send_message("", embed=embed, view=view)
+            embed = discord.Embed(
+                title="",
+                color=discord.Colour.blurple(),
+            )
+
+            tracklist_markdown = ""
+            for idx, track in enumerate(tracks):
+                tracklist_markdown += f"**{idx+1}**. {track.name} - {track.artist}\n"
+
+            embed.add_field(name="Search Results", value=tracklist_markdown)
+
+            view = SearchView(tracks, self.bot)
+            await interaction.response.send_message("", embed=embed, view=view)

--- a/djyosof/cogs/spotify.py
+++ b/djyosof/cogs/spotify.py
@@ -20,12 +20,14 @@ class SpotifyCog(commands.Cog):
         self,
         interaction: Interaction,
         query: Option(str, "Query to search for", required=False),
-        link: Option(str, "Link to Spotify media", required=False),
     ):
-        if not query and not link:
-            return
+        pattern = re.compile(
+            r"https://open.spotify.com/(track|album|playlist)/(.{22}).*"
+        )
+        matcher = pattern.search(link)
 
-        if link:
+        # media doesn't exist
+        if matcher:
             tracks = self.bot.players[AudioType.SPOTIFY].open_link(link)
             voice = await utilities.connect_or_move(interaction)
             if not voice:
@@ -45,7 +47,7 @@ class SpotifyCog(commands.Cog):
                 f"Added {len(tracks)} tracks to the queue"
             )
 
-        if query:
+        else:
             tracks = self.bot.players[AudioType.SPOTIFY].search(query)
 
             embed = discord.Embed(

--- a/djyosof/cogs/spotify.py
+++ b/djyosof/cogs/spotify.py
@@ -26,11 +26,11 @@ class SpotifyCog(commands.Cog):
         pattern = re.compile(
             r"https://open.spotify.com/(track|album|playlist)/(.{22}).*"
         )
-        matcher = pattern.search(link)
+        matcher = pattern.search(query)
 
         # media doesn't exist
         if matcher:
-            tracks = self.bot.players[AudioType.SPOTIFY].open_link(link)
+            tracks = self.bot.players[AudioType.SPOTIFY].open_link(query)
             voice = await utilities.connect_or_move(interaction)
             if not voice:
                 await interaction.response.send_message(

--- a/djyosof/cogs/spotify.py
+++ b/djyosof/cogs/spotify.py
@@ -34,8 +34,7 @@ class SpotifyCog(commands.Cog):
                     track, voice, interaction
                 )
 
-
-        if query
+        if query:
             tracks = self.bot.players[AudioType.SPOTIFY].search(query)
 
             embed = discord.Embed(

--- a/djyosof/cogs/spotify.py
+++ b/djyosof/cogs/spotify.py
@@ -4,6 +4,7 @@ from discord.ext import commands
 from discord.commands import slash_command
 
 from djyosof.audio_types.playable_audio import AudioType
+from djyosof.cogs import utilities
 from djyosof.players.spotify import SpotifySource
 from djyosof.views.search_view import SearchView
 from settings import CONFIG

--- a/djyosof/cogs/spotify.py
+++ b/djyosof/cogs/spotify.py
@@ -27,7 +27,7 @@ class SpotifyCog(commands.Cog):
         if link:
             tracks = self.bot.players[AudioType.SPOTIFY].open_link(link)
             await self.bot.audio_players[interaction.guild_id].enqueue_and_play(
-                track[:1], voice, interaction
+                tracks[:1], voice, interaction
             )
             for track in tracks[1:]:
                 await self.bot.audio_players[interaction.guild_id].enqueue(

--- a/djyosof/cogs/spotify.py
+++ b/djyosof/cogs/spotify.py
@@ -38,7 +38,7 @@ class SpotifyCog(commands.Cog):
             )
             for track in tracks[1:]:
                 await self.bot.audio_players[interaction.guild_id].enqueue(
-                    track, voice, interaction
+                    track, interaction
                 )
 
         if query:

--- a/djyosof/cogs/spotify.py
+++ b/djyosof/cogs/spotify.py
@@ -26,6 +26,12 @@ class SpotifyCog(commands.Cog):
 
         if link:
             tracks = self.bot.players[AudioType.SPOTIFY].open_link(link)
+            voice = await utilities.connect_or_move(interaction)
+            if not voice:
+                await interaction.response.send_message(
+                    "Unable to connect to a voice channel :("
+                )
+                return
             await self.bot.audio_players[interaction.guild_id].enqueue_and_play(
                 tracks[:1], voice, interaction
             )

--- a/djyosof/cogs/spotify.py
+++ b/djyosof/cogs/spotify.py
@@ -41,6 +41,10 @@ class SpotifyCog(commands.Cog):
                     track, interaction
                 )
 
+            await interaction.response.send_message(
+                f"Added {len(tracks)} tracks to the queue"
+            )
+
         if query:
             tracks = self.bot.players[AudioType.SPOTIFY].search(query)
 

--- a/djyosof/cogs/spotify.py
+++ b/djyosof/cogs/spotify.py
@@ -1,3 +1,5 @@
+import re
+
 import discord
 from discord import Interaction, Option
 from discord.ext import commands

--- a/djyosof/cogs/spotify.py
+++ b/djyosof/cogs/spotify.py
@@ -34,7 +34,7 @@ class SpotifyCog(commands.Cog):
                 )
                 return
             await self.bot.audio_players[interaction.guild_id].enqueue_and_play(
-                tracks[:1], voice, interaction
+                tracks[0], voice, interaction
             )
             for track in tracks[1:]:
                 await self.bot.audio_players[interaction.guild_id].enqueue(

--- a/djyosof/cogs/spotify.py
+++ b/djyosof/cogs/spotify.py
@@ -19,7 +19,7 @@ class SpotifyCog(commands.Cog):
     async def spotify(
         self,
         interaction: Interaction,
-        query: Option(str, "Query to search for", required=False),
+        query: Option(str, "Query to search for", required=True),
     ):
         pattern = re.compile(
             r"https://open.spotify.com/(track|album|playlist)/(.{22}).*"

--- a/djyosof/players/audio_player.py
+++ b/djyosof/players/audio_player.py
@@ -37,7 +37,7 @@ class AudioPlayer:
     async def enqueue(self, track: PlayableAudio, interaction: Interaction):
         """Adds a track to the end of a queue."""
         await self.queue.put(track)
-        await interaction.response.send_message(
+        await interaction.followup.send_message(
             f"Added {track.name} by {track.artist} to the queue"
         )
 

--- a/djyosof/players/audio_player.py
+++ b/djyosof/players/audio_player.py
@@ -1,6 +1,6 @@
 """Contains class that controls playing audio"""
 
-from asyncio import Event, Queue
+from asyncio import Event, Queue, sleep
 
 from discord import VoiceClient, Interaction
 
@@ -49,8 +49,10 @@ class AudioPlayer:
             self.next.clear()
 
             if self.queue.empty():
-                await utilities.leave(interaction)
-                break
+                await sleep(10)
+                if self.queue.empty():
+                    await utilities.leave(interaction)
+                    break
 
             track = await self.queue.get()
             player = self.bot.players[track.get_type()]
@@ -68,3 +70,21 @@ class AudioPlayer:
             await self.next.wait()
 
         self.is_playing = False
+
+    def skip(
+        self,
+        voice: VoiceClient,
+    ):
+        # Stops the current song so next will be picked up
+        voice.stop()
+
+    def stop(
+        self,
+        voice: VoiceClient,
+    ):
+        # Clear queue and stop playing
+        for _ in range(self.queue.qsize()):
+            self.queue.get_nowait()
+            self.queue.task_done()
+
+        voice.stop()

--- a/djyosof/players/audio_player.py
+++ b/djyosof/players/audio_player.py
@@ -37,7 +37,7 @@ class AudioPlayer:
     async def enqueue(self, track: PlayableAudio, interaction: Interaction):
         """Adds a track to the end of a queue."""
         await self.queue.put(track)
-        await interaction.followup.send_message(
+        await interaction.followup.send(
             f"Added {track.name} by {track.artist} to the queue"
         )
 

--- a/djyosof/players/audio_player.py
+++ b/djyosof/players/audio_player.py
@@ -37,9 +37,6 @@ class AudioPlayer:
     async def enqueue(self, track: PlayableAudio, interaction: Interaction):
         """Adds a track to the end of a queue."""
         await self.queue.put(track)
-        await interaction.followup.send(
-            f"Added {track.name} by {track.artist} to the queue"
-        )
 
     async def play_loop(self, voice: VoiceClient, interaction: Interaction):
         """Loop to play through any songs in the queue."""

--- a/djyosof/players/base_source.py
+++ b/djyosof/players/base_source.py
@@ -1,0 +1,19 @@
+import abc
+from collections.abc import Callable
+
+from discord import VoiceClient
+
+from djyosof.audio_types.playable_audio import PlayableAudio
+
+
+class BaseSource:
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def play(
+        self,
+        track: PlayableAudio,
+        voice: VoiceClient,
+        after: Callable | None = None,
+    ):
+        return

--- a/djyosof/players/spotify.py
+++ b/djyosof/players/spotify.py
@@ -54,7 +54,7 @@ class SpotifySource:
         )
         if media_type == "track":
             tracks = [SpotifyTrack(response.json())]
-        else:
+        elif media_type == "album":
             album_json = resp.json()
             del album_json["tracks"]
             tracks_json = resp.json()["tracks"]["items"]
@@ -62,6 +62,8 @@ class SpotifySource:
             for item in tracks_json:
                 item["album"] = album_json
                 tracks.append(SpotifyTrack(item))
+        elif media_type == "playlist":  # TODO: fix album missing
+            tracks = [item for item in resp.json()["tracks"]["items"]]
 
         return tracks
 

--- a/djyosof/players/spotify.py
+++ b/djyosof/players/spotify.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Callable
 
 import discord

--- a/djyosof/players/spotify.py
+++ b/djyosof/players/spotify.py
@@ -10,9 +10,10 @@ import requests
 
 from settings import CONFIG
 from djyosof.audio_types.spotify_track import SpotifyTrack
+from djyosof.players.base_source import BaseSource
 
 
-class SpotifySource:
+class SpotifySource(BaseSource):
     def __init__(self):
         session_builder = Session.Builder().stored_file()
         if not session_builder.login_credentials:
@@ -62,8 +63,10 @@ class SpotifySource:
             for item in tracks_json:
                 item["album"] = album_json
                 tracks.append(SpotifyTrack(item))
-        elif media_type == "playlist":  # TODO: fix album missing
-            tracks = [item for item in resp.json()["tracks"]["items"]]
+        elif media_type == "playlist":
+            tracks = [
+                SpotifyTrack(item["track"]) for item in resp.json()["tracks"]["items"]
+            ]
 
         return tracks
 

--- a/djyosof/players/spotify.py
+++ b/djyosof/players/spotify.py
@@ -49,13 +49,17 @@ class SpotifySource:
 
         token = self.session.tokens().get("user-read-email")
         resp = requests.get(
-            "https://api.spotify.com/v1/{media_type}s/media_id",
+            f"https://api.spotify.com/v1/{media_type}s/{media_id}",
             headers={"Authorization": f"Bearer {token}"},
         )
         if media_type == "track":
             tracks = [SpotifyTrack(response.json())]
         else:
-            tracks = [SpotifyTrack(item) for item in resp.json()["tracks"]["items"]]
+            album_json = resp.json()
+            del album_json["tracks"]
+            tracks_json = resp.json()["tracks"]["items"]
+            tracks_json["album"] = album_json
+            tracks = [SpotifyTrack(item) for item in tracks_json]
 
         return tracks
 

--- a/djyosof/players/spotify.py
+++ b/djyosof/players/spotify.py
@@ -58,8 +58,11 @@ class SpotifySource:
             album_json = resp.json()
             del album_json["tracks"]
             tracks_json = resp.json()["tracks"]["items"]
-            tracks_json["album"] = album_json
-            tracks = [SpotifyTrack(item) for item in tracks_json]
+            track_json["album"] = album_json
+            tracks = []
+            for item in tracks_json:
+                item["album"] = album_json
+                tracks.append(SpotifyTrack(item))
 
         return tracks
 

--- a/djyosof/players/spotify.py
+++ b/djyosof/players/spotify.py
@@ -54,7 +54,7 @@ class SpotifySource(BaseSource):
             headers={"Authorization": f"Bearer {token}"},
         )
         if media_type == "track":
-            tracks = [SpotifyTrack(response.json())]
+            tracks = [SpotifyTrack(resp.json())]
         elif media_type == "album":
             album_json = resp.json()
             del album_json["tracks"]

--- a/djyosof/players/spotify.py
+++ b/djyosof/players/spotify.py
@@ -58,7 +58,6 @@ class SpotifySource:
             album_json = resp.json()
             del album_json["tracks"]
             tracks_json = resp.json()["tracks"]["items"]
-            track_json["album"] = album_json
             tracks = []
             for item in tracks_json:
                 item["album"] = album_json

--- a/djyosof/views/search_view.py
+++ b/djyosof/views/search_view.py
@@ -46,3 +46,6 @@ class SearchResultButton(discord.ui.Button):
         await self.bot.audio_players[interaction.guild_id].enqueue_and_play(
             self.track, voice, interaction
         )
+        await interaction.response.send_message(
+            f"Added {self.track.name} by {self.track.artist} to the queue"
+        )


### PR DESCRIPTION
Closes #3 #4 #5 

If you pass a link to the `/spotify` command it will grab the album/playlist/track from the link and play it.

Adds `/stop` command that clears the queue and stops the player.
Adds `/skip` command that stops the current song so the next one gets picked up.